### PR TITLE
🛠 Fix: Prevent Crash When app/Events Folder is Missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,4 @@ Homestead.yaml
 Homestead.json
 /.vagrant
 .phpunit.result.cache
-.idea/codeception.xml
-.idea/filament-workflows.iml
-.idea/modules.xml
-.idea/php.xml
-.idea/phpspec.xml
-.idea/phpunit.xml
-.idea/vcs.xml
+.idea/*

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -168,8 +168,11 @@ class Utils
         return $data;
     }
 
-    public static function listEvents($asSelect = true): array
+    public static function listEvents($forSelect = true): array
     {
+        if (!file_exists(app_path() . "/Events"))
+            return [];
+
         $data = [];
         $classes = [];
         foreach (scandir(app_path() . "/Events") as $file) {
@@ -180,13 +183,15 @@ class Utils
                 $classes[] = $class;
             }
         }
-        if ($asSelect) {
-            foreach ($classes as $class) {
-                $data[$class] = str(class_basename($class))->kebab()->replace('-', ' ')->title()->value();
-            }
-        } else {
-            $data = $classes;
+
+        if (!$forSelect) {
+            return $classes;
         }
+
+        foreach ($classes as $class) {
+            $data[$class] = str(class_basename($class))->kebab()->replace('-', ' ')->title()->value();
+        }
+
         return $data;
     }
 


### PR DESCRIPTION
## 🛠 Fix: Prevent Crash When `app/Events` Folder is Missing

### What Changed

- **Refactored** `Utils::listEvents()` to:
  - **Check for the existence** of the `app/Events` directory before attempting to scan it.
  - Return an **empty array** early if the folder is missing (restoring the behavior from v0.1.0).
  - **Renamed** `$asSelect` to `$forSelect` for clarity and consistency with similar methods.
  - Reorganized logic for improved readability.

- **.gitignore cleanup**:
  - Removed redundant `.idea/*` entries.
  - Simplified to a single `.idea/*` rule.

### Why

Fixes a bug where the system **breaks if the `app/Events` folder does not exist**, which started happening after changes in version `0.2.0`.

This ensures the method fails gracefully and aligns the behavior with expectations from `v0.1.0`, improving developer experience and robustness when installing the package in projects without custom events.

### Related Issue
#2 
> When installing the lib without an `app/Events/*` file the system breaks.  
> Expected behavior: When no Events folder is found we should return an empty list from the `listEvents` method.

### Notes

Thanks for this library—this small fix makes it easier to use out of the box across multiple projects! 🎉
