### PR TITLE
Updated Utils.php for support more fields types

### DIFF
--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -324,7 +324,9 @@ class Utils
                 if (is_array($value)) {
                     $arr_data = [];
                     foreach ($value as $k => $subValue) {
-                        $arr_data[$k] = self::processMagicAttribute($model, $subValue);
+                        if (is_string($subValue)) {
+                            $arr_data[$k] = self::processMagicAttribute($model, $subValue);
+                        }
                     }
                     $data[$key] = $arr_data;
 


### PR DESCRIPTION
**What Changed**
Added a check in processMagicAttributes function of Utils.php for support more fields types. This check doesn't impact on others fields types that already working.

**Why**
Some fields save a different structure and when magic attributes are parsed this function send an error.
In particular this fix enable to use this field: https://filamentphp.com/plugins/infinityxtech-unlayer