### PR TITLE
Fix conditions is-equal-to

### DIFF
--- a/src/Jobs/PrepareModelEventForWorkflow.php
+++ b/src/Jobs/PrepareModelEventForWorkflow.php
@@ -107,7 +107,7 @@ class PrepareModelEventForWorkflow implements ShouldQueue
             switch ($condition->operator) {
                 case "is-equal-to":
                 {
-                    $conditions_results[] = $attribute instanceof Carbon ? $attribute->equalTo($condition->compare_value) : $condition == $condition->compare_value;
+                    $conditions_results[] = $attribute instanceof Carbon ? $attribute->equalTo($condition->compare_value) : $attribute == $condition->compare_value;
                     break;
                 }
                 case "is-not-equal-to":

--- a/src/Services/WorkflowService.php
+++ b/src/Services/WorkflowService.php
@@ -51,7 +51,7 @@ class WorkflowService
             switch ($condition->operator) {
                 case "is-equal-to":
                 {
-                    $conditions_results[] = $attribute instanceof Carbon ? $attribute->equalTo($condition->compare_value) : $condition == $condition->compare_value;
+                    $conditions_results[] = $attribute instanceof Carbon ? $attribute->equalTo($condition->compare_value) : $attribute == $condition->compare_value;
                     break;
                 }
                 case "is-not-equal-to":

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -385,7 +385,7 @@ class Utils
             switch ($condition->operator) {
                 case "is-equal-to":
                 {
-                    $conditions_results[] = $attribute instanceof Carbon ? $attribute->equalTo($condition->compare_value) : $condition == $condition->compare_value;
+                    $conditions_results[] = $attribute instanceof Carbon ? $attribute->equalTo($condition->compare_value) : $attribute == $condition->compare_value;
                     break;
                 }
                 case "is-not-equal-to":


### PR DESCRIPTION
The comparison "is-equal-to" wasn't working because compare variable $condition and not $attribute.