### PR TITLE
Add a features that allows changing the model name and model attributes name when displaying

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,46 @@ class Order extends Model
 }
 ```
 
+To change the model display name you can use the getModelName() static function:
+
+```php
+use Monzer\FilamentWorkflows\Traits\TrackWorkflowModelEvents;
+
+class Order extends Model
+{
+    use TrackWorkflowModelEvents;
+
+    public static function getModelName(): string
+    {
+        return __("order.plural"); //for example 
+    }
+}
+```
+
+To change the attributes display name you can use the getAttributeName() static function:
+
+```php
+use Monzer\FilamentWorkflows\Traits\TrackWorkflowModelEvents;
+
+class Order extends Model
+{
+    use TrackWorkflowModelEvents;
+
+    public static function getAttributeName(string $attribute): ?string
+    {
+        switch ($attribute) {
+            case 'id':
+                return __("order.fields.id");
+            case 'type':
+                return __("order.fields.type");
+            //... extra 
+            default:
+                return null;
+        }
+    }
+}
+```
+
 ## NOTE:
 
 You need to run php artisan schedule:work command to run the workflows.

--- a/src/Traits/TrackWorkflowModelEvents.php
+++ b/src/Traits/TrackWorkflowModelEvents.php
@@ -7,6 +7,16 @@ use Monzer\FilamentWorkflows\Jobs\PrepareModelEventForWorkflow;
 
 trait TrackWorkflowModelEvents
 {
+    public static function getModelName(): string
+    {
+        return str(class_basename(static::class))->kebab()->replace('-', ' ')->title()->value();
+    }
+
+    public static function getAttributeName(string $attribute): ?string
+    {
+        return null;
+    }
+
     public static function bootTrackWorkflowModelEvents()
     {
         static::created(function (Model $model) {

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -160,7 +160,7 @@ class Utils
 
         if ($asSelect) {
             foreach ($models_that_uses_track_workflow_model_events_trait as $model_class) {
-                $data[$model_class] = str(class_basename($model_class))->kebab()->replace('-', ' ')->title()->value();
+                 $data[$model_class] = $model_class::getModelName();
             }
         } else {
             $data = $models_that_uses_track_workflow_model_events_trait;
@@ -258,8 +258,12 @@ class Utils
         if ($asSelect) {
             $attributes = array_combine(array_values($attributes), array_values($attributes));
             foreach ($attributes as $key => $value) {
-                $mutated = self::isModelAttributeMutated($trigger_class, $key) ? "- " : "";
-                $attributes[$key] = str($mutated . $value)->replace('_', ' ')->ucfirst()->title()->value();
+                if (method_exists($trigger_class, 'getAttributeName') && ($defaultAttributeName = $trigger_class::getAttributeName($key))) {
+                    $attributes[$key] = $defaultAttributeName;
+                } else {
+                    $mutated = self::isModelAttributeMutated($trigger_class, $key) ? "- " : "";
+                    $attributes[$key] = str($mutated . $value)->replace('_', ' ')->ucfirst()->title()->value();
+                }
             }
         }
 


### PR DESCRIPTION
## Add a features that allows changing the model name and model attributes name when displaying

To change the model display name you can use the getModelName() static function:

```php
use Monzer\FilamentWorkflows\Traits\TrackWorkflowModelEvents;

class Order extends Model
{
    use TrackWorkflowModelEvents;

    public static function getModelName(): string
    {
        return __("order.plural"); //for example 
    }
}
```

To change the attributes display name you can use the getAttributeName() static function:

```php
use Monzer\FilamentWorkflows\Traits\TrackWorkflowModelEvents;

class Order extends Model
{
    use TrackWorkflowModelEvents;

    public static function getAttributeName(string $attribute): ?string
    {
        switch ($attribute) {
            case 'id':
                return __("order.fields.id");
            case 'type':
                return __("order.fields.type");
            //... extra 
            default:
                return null;
        }
    }
}
```